### PR TITLE
Allows us to specify beta releases inside RELEASE_NOTES.md during NuGet publication, without passing in any additional commandline flags.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -22,15 +22,22 @@ let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynami
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
 let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
+
+let releaseNotes =
+    File.ReadLines (__SOURCE_DIRECTORY__ @@ "RELEASE_NOTES.md")
+    |> ReleaseNotesHelper.parseReleaseNotes
+
+let versionFromReleaseNotes =
+    match releaseNotes.SemVer.PreRelease with
+    | Some r -> r.Origin
+    | None -> ""
+
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
-    | "" -> ""
+    | "" -> versionFromReleaseNotes
     | str -> str
-
-let releaseNotes =
-    File.ReadLines "./RELEASE_NOTES.md"
-    |> ReleaseNotesHelper.parseReleaseNotes
+    
 
 // Directories
 let toolsDir = __SOURCE_DIRECTORY__ @@ "tools"


### PR DESCRIPTION

ported https://github.com/akkadotnet/akka.net/pull/4175