### PR TITLE
run `All` instead of `RunTests`

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -45,8 +45,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-      - name: Run './build.cmd RunTests'
-        run: ./build.cmd RunTests
+      - name: Run './build.cmd All'
+        run: ./build.cmd All
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
   ubuntu-latest:
@@ -67,7 +67,7 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-      - name: Run './build.cmd RunTests'
-        run: ./build.cmd RunTests
+      - name: Run './build.cmd All'
+        run: ./build.cmd All
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -15,7 +15,7 @@ using Nuke.Common.Utilities;
     AutoGenerate = true,
     OnPushBranches = new[] { "master", "dev" },
     OnPullRequestBranches = new[] { "master", "dev" },
-    InvokedTargets = new[] { nameof(RunTests) },
+    InvokedTargets = new[] { nameof(All) },
     PublishArtifacts = false,
     EnableGitHubContext = true)
 ]


### PR DESCRIPTION
Fix for https://github.com/petabridge/petabridge-dotnet-new/issues/245

pr validation should run `All` instead of `RunTests`